### PR TITLE
feat: support responsive grid

### DIFF
--- a/example/Example.stories.tsx
+++ b/example/Example.stories.tsx
@@ -73,3 +73,40 @@ DifferentColor.parameters = {
 		color: 'rgba(0, 0, 255, 0.1)',
 	},
 };
+
+export const ResponsiveGrid: Story = () => (
+	<>
+		<style dangerouslySetInnerHTML={{__html:`
+		 body {
+		  --columns: 4;
+		  --gap: 8px;
+		  --gutter: 16px;
+          }
+
+		  @media (min-width: 768px) {
+		  body {
+		    --columns: 8;
+		    --gap: 12px;
+		    --gutter: 24px;
+		    }
+		  }
+
+		  @media (min-width: 1024px) {
+		  body {
+		    --columns: 12;
+		    --gap: 24px;
+		    --gutter: 48px;
+		    }
+		  }
+
+		`}}/>
+		<ComponentTest />
+	</>
+)
+ResponsiveGrid.parameters = {
+	grid: {
+		columns: 'var(--columns)',
+		gutter: 'var(--gutter)',
+		gap: 'var(--gap)',
+	},
+};

--- a/example/Example.stories.tsx
+++ b/example/Example.stories.tsx
@@ -76,7 +76,9 @@ DifferentColor.parameters = {
 
 export const ResponsiveGrid: Story = () => (
 	<>
-		<style dangerouslySetInnerHTML={{__html:`
+		<style
+			dangerouslySetInnerHTML={{
+				__html: `
 		 body {
 		  --columns: 4;
 		  --gap: 8px;
@@ -99,10 +101,12 @@ export const ResponsiveGrid: Story = () => (
 		    }
 		  }
 
-		`}}/>
+		`,
+			}}
+		/>
 		<ComponentTest />
 	</>
-)
+);
 ResponsiveGrid.parameters = {
 	grid: {
 		columns: 'var(--columns)',

--- a/index.d.ts
+++ b/index.d.ts
@@ -5,7 +5,11 @@ export interface GridConfig {
 	/**
 	 * Number of columns, default: 12
 	 */
-	columns?: number | undefined;
+	columns?: number | string | undefined;
+	/**
+	 * Maximum number of columns, default: 24
+	 */
+	maxColumns?: number | undefined;
 	/**
 	 * Gap between columns
 	 */

--- a/index.d.ts
+++ b/index.d.ts
@@ -3,13 +3,9 @@
  */
 export interface GridConfig {
 	/**
-	 * Number of columns, default: 12
+	 * Number of columns, default: 12 max: 24
 	 */
 	columns?: number | string | undefined;
-	/**
-	 * Maximum number of columns, default: 24
-	 */
-	maxColumns?: number | undefined;
 	/**
 	 * Gap between columns
 	 */
@@ -18,12 +14,10 @@ export interface GridConfig {
 	 * Gutter (margin) on the left and/or right.
 	 */
 	gutter?: string | [string, string] | undefined;
-
 	/**
 	 * maximum allowed width
 	 */
 	maxWidth?: string | undefined;
-
 	/**
 	 * Sets the color used for the column guides, defaults to red (rgba(255, 0, 0, 0.1))
 	 */

--- a/readme.md
+++ b/readme.md
@@ -129,6 +129,30 @@ Example.parameters = {
 };
 ```
 
+## Responsive grid
+Storybook-addon-grid does not support responsive grid by itself, delegating this functionality to you.
+
+Why? Our intention is to match your application settings, not to replicate them.
+We hope you are using css media queries to control your grid system in the real application, and would like to _tap into_ them
+
+#### Addon configuration
+```tsx
+Example.parameters = {
+    grid: {
+        // instead of number - give us your custom variable names for
+        // number of columns
+        columns: 'var(--columns)',
+        // gutter
+        gutter: 'var(--gutter)',
+        // gap
+        gap: 'var(--gap)',
+    }
+}
+```
+Then - it's up to you to make those variables work. We would like to be in sync with your app and just work as a part of it.
+
+Example could be sound in our own storybook [ResponsiveGrid](./example/Example.stories.tsx).
+
 ## 📚 Further Readings
 
 - https://compassofdesign.com/articles/design-principle-1-guides-gutters-and-grids

--- a/readme.md
+++ b/readme.md
@@ -130,26 +130,30 @@ Example.parameters = {
 ```
 
 ## Responsive grid
+
 Storybook-addon-grid does not support responsive grid by itself, delegating this functionality to you.
 
-Why? Our intention is to match your application settings, not to replicate them.
-We hope you are using css media queries to control your grid system in the real application, and would like to _tap into_ them
+Why? Our intention is to match your application settings, not to replicate them. We hope you are using css media queries
+to control your grid system in the real application, and would like to _tap into_ them
 
 #### Addon configuration
+
 ```tsx
 Example.parameters = {
-    grid: {
-        // instead of number - give us your custom variable names for
-        // number of columns
-        columns: 'var(--columns)',
-        // gutter
-        gutter: 'var(--gutter)',
-        // gap
-        gap: 'var(--gap)',
-    }
-}
+  grid: {
+    // instead of number - give us your custom variable names for
+    // number of columns
+    columns: 'var(--columns)',
+    // gutter
+    gutter: 'var(--gutter)',
+    // gap
+    gap: 'var(--gap)',
+  },
+};
 ```
-Then - it's up to you to make those variables work. We would like to be in sync with your app and just work as a part of it.
+
+Then - it's up to you to make those variables work. We would like to be in sync with your app and just work as a part of
+it.
 
 Example could be sound in our own storybook [ResponsiveGrid](./example/Example.stories.tsx).
 

--- a/readme.md
+++ b/readme.md
@@ -129,33 +129,41 @@ Example.parameters = {
 };
 ```
 
-## Responsive grid
+### Responsive properties
 
-Storybook-addon-grid does not support responsive grid by itself, delegating this functionality to you.
+The way `storybook-addon-grid` solves responsive properties is leaving this up to you. We don't you to build
+abstractions and implementations for this addon, we want to reuse existing patterns you may already be using.
 
-Why? Our intention is to match your application settings, not to replicate them. We hope you are using css media queries
-to control your grid system in the real application, and would like to _tap into_ them
+In fact all properties map through to css, so any css variable you expose is consumable.
 
-#### Addon configuration
+eg:
 
-```tsx
-Example.parameters = {
+```css
+// file: my-styles.css
+@media (min-width: 768px) {
+  :root {
+    --columns: 8;
+    --gap: 12px;
+    --gutter: 24px;
+    }
+  }
+}
+```
+
+```ts
+Story.parameters = {
   grid: {
-    // instead of number - give us your custom variable names for
-    // number of columns
+    // a custom variable names for the number of columns
     columns: 'var(--columns)',
-    // gutter
+    // or the gutter
     gutter: 'var(--gutter)',
-    // gap
+    // or the gap
     gap: 'var(--gap)',
   },
 };
 ```
 
-Then - it's up to you to make those variables work. We would like to be in sync with your app and just work as a part of
-it.
-
-Example could be sound in our own storybook [ResponsiveGrid](./example/Example.stories.tsx).
+You can see this in action over at our [example story `ResponsiveGrid`](./example/Example.stories.tsx).
 
 ## 📚 Further Readings
 

--- a/src/components/Grids.tsx
+++ b/src/components/Grids.tsx
@@ -8,7 +8,7 @@ import { ADDON_ID, PARAM_KEY } from '../constants';
 import { Grids } from './ui';
 
 const ManagerRenderedGrids = () => {
-	const { animation, columns, gap, color, gutter, maxWidth, disable } =
+	const { animation, columns, gap, color, gutter, maxWidth, disable, maxColumns } =
 		useParameter<AddonParameters>(PARAM_KEY, {});
 	const [state] = useAddonState<AddonState>(ADDON_ID);
 
@@ -21,6 +21,7 @@ const ManagerRenderedGrids = () => {
 			visible={disable != null ? !disable : state?.visible ?? false}
 			gutter={gutter}
 			maxWidth={maxWidth}
+			maxColumns={maxColumns}
 		/>
 	);
 };

--- a/src/components/Grids.tsx
+++ b/src/components/Grids.tsx
@@ -8,8 +8,16 @@ import { ADDON_ID, PARAM_KEY } from '../constants';
 import { Grids } from './ui';
 
 const ManagerRenderedGrids = () => {
-	const { animation, columns, gap, color, gutter, maxWidth, disable, maxColumns } =
-		useParameter<AddonParameters>(PARAM_KEY, {});
+	const {
+		animation,
+		columns,
+		gap,
+		color,
+		gutter,
+		maxWidth,
+		disable,
+		maxColumns,
+	} = useParameter<AddonParameters>(PARAM_KEY, {});
 	const [state] = useAddonState<AddonState>(ADDON_ID);
 
 	return (

--- a/src/components/Grids.tsx
+++ b/src/components/Grids.tsx
@@ -8,16 +8,8 @@ import { ADDON_ID, PARAM_KEY } from '../constants';
 import { Grids } from './ui';
 
 const ManagerRenderedGrids = () => {
-	const {
-		animation,
-		columns,
-		gap,
-		color,
-		gutter,
-		maxWidth,
-		disable,
-		maxColumns,
-	} = useParameter<AddonParameters>(PARAM_KEY, {});
+	const { animation, columns, gap, color, gutter, maxWidth, disable } =
+		useParameter<AddonParameters>(PARAM_KEY, {});
 	const [state] = useAddonState<AddonState>(ADDON_ID);
 
 	return (
@@ -29,7 +21,6 @@ const ManagerRenderedGrids = () => {
 			visible={disable != null ? !disable : state?.visible ?? false}
 			gutter={gutter}
 			maxWidth={maxWidth}
-			maxColumns={maxColumns}
 		/>
 	);
 };

--- a/src/components/ui.tsx
+++ b/src/components/ui.tsx
@@ -36,40 +36,40 @@ const Wrapper = styled.div<{ active: boolean; animation: boolean }>(
 	}),
 );
 
-const Grid = styled.div<Exclude<GridConfig, 'color' | 'animation'> & {grid: string}>(
-	({ gap, gutter, maxWidth, grid }) => {
-		let gutterRight = '0',
-			gutterLeft = '0';
-		if (Array.isArray(gutter)) {
-			([gutterLeft, gutterRight] = gutter)
-		} else if (gutter != null) {
-			gutterLeft = gutterRight = gutter;
-		}
+const Grid = styled.div<
+	Exclude<GridConfig, 'color' | 'animation'> & { grid: string }
+>(({ gap, gutter, maxWidth, grid }) => {
+	let gutterRight = '0',
+		gutterLeft = '0';
+	if (Array.isArray(gutter)) {
+		[gutterLeft, gutterRight] = gutter;
+	} else if (gutter != null) {
+		gutterLeft = gutterRight = gutter;
+	}
 
-		return {
-			position: 'fixed',
-			top: '0',
-			bottom: '0',
-			left: '0',
-			right: '0',
+	return {
+		position: 'fixed',
+		top: '0',
+		bottom: '0',
+		left: '0',
+		right: '0',
 
-			display: 'grid',
-			gridTemplateColumns: grid,
-			gridTemplateRows: '100%',
-			gridColumnGap: gap,
+		display: 'grid',
+		gridTemplateColumns: grid,
+		gridTemplateRows: '100%',
+		gridColumnGap: gap,
 
-			width: '100%',
-			height: '100%',
+		width: '100%',
+		height: '100%',
 
-			margin: '0 auto',
-			maxWidth,
-			padding: `0 ${gutterRight} 0 ${gutterLeft}`,
+		margin: '0 auto',
+		maxWidth,
+		padding: `0 ${gutterRight} 0 ${gutterLeft}`,
 
-			boxSizing: 'border-box',
-			pointerEvents: 'none',
-		};
-	},
-);
+		boxSizing: 'border-box',
+		pointerEvents: 'none',
+	};
+});
 
 const Column = styled.div<{ color: string }>(({ color }) => ({
 	width: '100%',
@@ -88,10 +88,13 @@ export const Grids: FunctionComponent<
 	color = 'rgba(255, 0, 0, 0.1)',
 	gutter = '50px',
 	maxWidth = '1024px',
-	maxColumns = 24
+	maxColumns = 24,
 }) => {
-	const numberOfColumns = typeof(columns) ==='number' ? columns : maxColumns;
-	const grid = typeof(columns) ==='number' ? `repeat(${columns}, 1fr)` : `repeat(var(${columns.match(/var\((.*)\)/)![1]}), 1fr)`
+	const numberOfColumns = typeof columns === 'number' ? columns : maxColumns;
+	const grid =
+		typeof columns === 'number'
+			? `repeat(${columns}, 1fr)`
+			: `repeat(var(${columns.match(/var\((.*)\)/)![1]}), 1fr)`;
 
 	const columnDivs = useMemo(
 		() =>
@@ -102,7 +105,7 @@ export const Grids: FunctionComponent<
 	);
 
 	const gridNodes = (
-		<Grid grid={grid} gap={gap} gutter={gutter} maxWidth={maxWidth} >
+		<Grid grid={grid} gap={gap} gutter={gutter} maxWidth={maxWidth}>
 			{columnDivs}
 		</Grid>
 	);

--- a/src/components/ui.tsx
+++ b/src/components/ui.tsx
@@ -5,6 +5,7 @@ import { ADDON_ID } from 'src/constants';
 import type { AddonState, GridConfig } from 'storybook-addon-grid';
 
 const ANIMATION_DURATION = 130;
+const MAX_COLUMNS = 24;
 
 const fadeIn = keyframes`
 	from {
@@ -36,40 +37,37 @@ const Wrapper = styled.div<{ active: boolean; animation: boolean }>(
 	}),
 );
 
-const Grid = styled.div<
-	Exclude<GridConfig, 'color' | 'animation'> & { grid: string }
->(({ gap, gutter, maxWidth, grid }) => {
-	let gutterRight = '0',
-		gutterLeft = '0';
-	if (Array.isArray(gutter)) {
-		[gutterLeft, gutterRight] = gutter;
-	} else if (gutter != null) {
-		gutterLeft = gutterRight = gutter;
-	}
+const Grid = styled.div<Omit<Required<GridConfig>, 'color' | 'animation'>>(
+	({ gap, gutter, maxWidth, columns }) => {
+		let gutterRight = '0',
+			gutterLeft = '0';
+		if (Array.isArray(gutter)) {
+			[gutterLeft, gutterRight] = gutter;
+		} else if (gutter != null) {
+			gutterLeft = gutterRight = gutter;
+		}
 
-	return {
-		position: 'fixed',
-		top: '0',
-		bottom: '0',
-		left: '0',
-		right: '0',
+		return {
+			position: 'fixed',
+			inset: '0',
 
-		display: 'grid',
-		gridTemplateColumns: grid,
-		gridTemplateRows: '100%',
-		gridColumnGap: gap,
+			display: 'grid',
+			gridTemplateColumns: `repeat(min(${columns}, ${MAX_COLUMNS}), 1fr)`,
+			gridTemplateRows: '100%',
+			gridColumnGap: gap,
 
-		width: '100%',
-		height: '100%',
+			width: '100%',
+			height: '100%',
 
-		margin: '0 auto',
-		maxWidth,
-		padding: `0 ${gutterRight} 0 ${gutterLeft}`,
+			margin: '0 auto',
+			maxWidth,
+			padding: `0 ${gutterRight} 0 ${gutterLeft}`,
 
-		boxSizing: 'border-box',
-		pointerEvents: 'none',
-	};
-});
+			boxSizing: 'border-box',
+			pointerEvents: 'none',
+		};
+	},
+);
 
 const Column = styled.div<{ color: string }>(({ color }) => ({
 	width: '100%',
@@ -88,24 +86,17 @@ export const Grids: FunctionComponent<
 	color = 'rgba(255, 0, 0, 0.1)',
 	gutter = '50px',
 	maxWidth = '1024px',
-	maxColumns = 24,
 }) => {
-	const numberOfColumns = typeof columns === 'number' ? columns : maxColumns;
-	const grid =
-		typeof columns === 'number'
-			? `repeat(${columns}, 1fr)`
-			: `repeat(var(${columns.match(/var\((.*)\)/)![1]}), 1fr)`;
-
 	const columnDivs = useMemo(
 		() =>
-			Array.from({ length: numberOfColumns }).map((_, index) => (
-				<Column key={index} color={color} />
-			)),
-		[numberOfColumns, color],
+			Array.from({
+				length: typeof columns === 'number' ? columns : MAX_COLUMNS,
+			}).map((_, index) => <Column key={index} color={color} />),
+		[columns, color],
 	);
 
 	const gridNodes = (
-		<Grid grid={grid} gap={gap} gutter={gutter} maxWidth={maxWidth}>
+		<Grid gap={gap} gutter={gutter} maxWidth={maxWidth} columns={columns}>
 			{columnDivs}
 		</Grid>
 	);

--- a/src/components/ui.tsx
+++ b/src/components/ui.tsx
@@ -36,13 +36,12 @@ const Wrapper = styled.div<{ active: boolean; animation: boolean }>(
 	}),
 );
 
-const Grid = styled.div<Exclude<GridConfig, 'color' | 'animation'>>(
-	({ columns, gap, gutter, maxWidth }) => {
+const Grid = styled.div<Exclude<GridConfig, 'color' | 'animation'> & {grid: string}>(
+	({ gap, gutter, maxWidth, grid }) => {
 		let gutterRight = '0',
 			gutterLeft = '0';
 		if (Array.isArray(gutter)) {
-			gutterLeft = gutter[0];
-			gutterRight = gutter[0];
+			([gutterLeft, gutterRight] = gutter)
 		} else if (gutter != null) {
 			gutterLeft = gutterRight = gutter;
 		}
@@ -55,7 +54,8 @@ const Grid = styled.div<Exclude<GridConfig, 'color' | 'animation'>>(
 			right: '0',
 
 			display: 'grid',
-			gridTemplateColumns: `repeat(${columns}, 1fr)`,
+			gridTemplateColumns: grid,
+			gridTemplateRows: '100%',
 			gridColumnGap: gap,
 
 			width: '100%',
@@ -88,17 +88,21 @@ export const Grids: FunctionComponent<
 	color = 'rgba(255, 0, 0, 0.1)',
 	gutter = '50px',
 	maxWidth = '1024px',
+	maxColumns = 24
 }) => {
+	const numberOfColumns = typeof(columns) ==='number' ? columns : maxColumns;
+	const grid = typeof(columns) ==='number' ? `repeat(${columns}, 1fr)` : `repeat(var(${columns.match(/var\((.*)\)/)![1]}), 1fr)`
+
 	const columnDivs = useMemo(
 		() =>
-			Array.from({ length: columns }).map((_, index) => (
+			Array.from({ length: numberOfColumns }).map((_, index) => (
 				<Column key={index} color={color} />
 			)),
-		[columns, color],
+		[numberOfColumns, color],
 	);
 
 	const gridNodes = (
-		<Grid columns={columns} gap={gap} gutter={gutter} maxWidth={maxWidth}>
+		<Grid grid={grid} gap={gap} gutter={gutter} maxWidth={maxWidth} >
 			{columnDivs}
 		</Grid>
 	);


### PR DESCRIPTION
Was looking at tremendous work happening at https://github.com/maraisr/storybook-addon-grid/pull/11 and probably there are too many changes.

Let's keep in mind why we want responsive grid - only because the target application needs it.

So, let's ask yourself a question - and how the target application gonna do it? How it will provide different grid settings for different media points?

The answer is "somehow", and we want to tap-into that somehow. Be a part of it, not replicate in any way.

-------

Long story short - embrace css variables and let application "CSS configuration" let us know what to do.

```tsx
Example.parameters = {
    grid: {
        columns: 'var(--columns)',
        gutter: 'var(--gutter)',
        gap: 'var(--gap)',
    }
}
```

> PS: gutters and gap already works this way. Now `columns` can use css var.

fixes #5 
closes #11 