### PR TITLE
Update prev.visible to handle undefined

### DIFF
--- a/src/components/Tools.tsx
+++ b/src/components/Tools.tsx
@@ -25,7 +25,7 @@ export const Tools = () => {
 		setState(
 			(prev) => ({
 				...prev,
-				visible: !prev?.visible,
+				visible: !prev?.visible ?? false,
 			}),
 			{
 				persistence: 'session',

--- a/src/components/Tools.tsx
+++ b/src/components/Tools.tsx
@@ -25,7 +25,7 @@ export const Tools = () => {
 		setState(
 			(prev) => ({
 				...prev,
-				visible: !prev.visible,
+				visible: !prev?.visible,
 			}),
 			{
 				persistence: 'session',


### PR DESCRIPTION
For Storybook 6.5.12 it is breaking because `prev` is undefined initially


<img width="602" alt="Screen Shot 2022-10-08 at 11 03 23 AM" src="https://user-images.githubusercontent.com/6688699/194714158-4320694e-d17d-498d-bfa1-a9d0a3914ab3.png">
<img width="1129" alt="Screen Shot 2022-10-08 at 11 03 15 AM" src="https://user-images.githubusercontent.com/6688699/194714159-f2fa2368-81f1-47f3-80ad-6440a2d00b66.png">
